### PR TITLE
Use named relationships and custom table names

### DIFF
--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -7,48 +7,46 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 
 class BelongsToManyField extends Field
 {
-    
-    public $showOnIndex = false;
-    public $showOnDetail = false;
-    /**
-     * The field's component.
-     *
-     * @var string
-     */
-    
-    public $component = 'BelongsToManyField';
-
-    public $relationModel;
-
-    public function options($options)
-    {
-        $options = collect($options);
-        return $this->withMeta(['options' => $options]);
-    }
-
-    public function relationModel($model)
-    {
-        $this->relationModel = $model;
-        return $this;
-    }
-
-    public function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
-    {
-        if (strlen($request[$requestAttribute]) > 2) {
-            $requestValue = json_decode($request[$requestAttribute]);
-            $class = get_class($model);
-            $class::saved(function ($model) use ($requestValue, $attribute) {
-                $model->syncManyValues($requestValue, $attribute, $this->relationModel);
-            });
-        }
-    }
-
-    public function resolve($resource, $attribute = null)
-    {
-        parent::resolve($resource, $attribute);
-        $value = json_decode($resource->{$this->attribute});
-        if ($value) {
-            $this->value = $value;
-        }
-    }
+	
+	public $showOnIndex = false;
+	public $showOnDetail = false;
+	/**
+	 * The field's component.
+	 *
+	 * @var string
+	 */
+	
+	public $component = 'BelongsToManyField';
+	
+	public $relationModel;
+	
+	public function options($options)
+	{
+		$options = collect($options);
+		return $this->withMeta(['options' => $options]);
+	}
+	
+	public function relationModel($model)
+	{
+		$this->relationModel = $model;
+		return $this;
+	}
+	
+	public function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+	{
+		$requestValue = strlen($request[$requestAttribute]) > 2 ? json_decode($request[$requestAttribute]) : [];
+		$class = get_class($model);
+		$class::saved(function ($model) use ($requestValue, $attribute) {
+			$model->syncManyValues($requestValue, $attribute, $this->relationModel);
+		});
+	}
+	
+	public function resolve($resource, $attribute = null)
+	{
+		parent::resolve($resource, $attribute);
+		$value = json_decode($resource->{$this->attribute});
+		if ($value) {
+			$this->value = $value;
+		}
+	}
 }

--- a/src/HasBelongsToMany.php
+++ b/src/HasBelongsToMany.php
@@ -18,10 +18,10 @@ trait HasBelongsToMany
         $model = app($relationModel);
         return $this->belongsToMany($model);
     }
-
-    public function syncManyValues($values, $attribute, $relationModel)
-    {
-        $arrayIds = array_column($values, 'id');
-        $this->model($relationModel)->sync($arrayIds);
-    }
+	
+	public function syncManyValues($values, $attribute, $relationModel)
+	{
+		$arrayIds = array_column($values, 'id');
+		$this->$attribute()->sync($arrayIds);
+	}
 }


### PR DESCRIPTION
Hello,
We've been using this field in our projects and love the user experience.
However I noticed that it only allows for relationships following the standard conventions and it doesn't work with models having several relationships to the same model.

This patch fixes this and also saves the field if the field is empty. With the current behavior you can't remove all the tags after adding them. The last one always stays even if you remove it in the UI.