### PR TITLE
Fix a bug when there's no input

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "benjacho/belongs-to-many-field",
+    "name": "ericphamhoang/belongs-to-many-field",
     "description": "belongsToMany nova representation in field.",
     "keywords": [
         "laravel",

--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -44,7 +44,11 @@ class BelongsToManyField extends Field
         $this->fillUsing(function($request, $model, $attribute, $requestAttribute) use($resource) {
             if(is_subclass_of($model, 'Illuminate\Database\Eloquent\Model')) {
                 $model::saved(function($model) use($attribute, $request) {
-                    $values = array_column(json_decode($request->$attribute, true),'id');
+                    $inp = json_decode($request->$attribute, true);
+                    if ($inp !== null)
+                        $values = array_column($inp,'id');
+                    else 
+                        $values=[];
                     $model->$attribute()->sync(
                         $values
                     );


### PR DESCRIPTION
Hey man, thanks for this great plugin! I've found a bug that when I deliberately hide the request field (using Nova Dependency Manager) then it doesn't allow me to update the resource

I've added a quick fix on this. Please disregard the package name change. If you approve my changes I will remove my package from Packagist