### PR TITLE
Resources always sorted by "name" - even when using "optionsLabel"

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -32,7 +32,7 @@ class ResourceController
                     $optionsLabel => $resource->title(),
                     'value' => $resource->getKey(),
                 ];
-            })->sortBy('name')
+            })
             ->values();
     }
 }


### PR DESCRIPTION
This should be a super easy issue to fix.

Basically my database model does not have a `name` column, which is fine because I can just use `optionsLabel` function to specify `keyword` as the column that's to be used for the option titles.

Works great.
![image](https://user-images.githubusercontent.com/1063088/80409924-4f476000-888f-11ea-9bcc-607116ef70a5.png)

Now if I wanted sort ^ that list alphabetically, I should be able to do that by overriding the `relatableQuery` method on my Keyword model like this:
![image](https://user-images.githubusercontent.com/1063088/80410144-b9f89b80-888f-11ea-9046-c8fac5bbec16.png)

The problem is that the sort order gets completely overwritten by this piece of logic inside ResourceController.php here:
https://github.com/Benjacho/belongs-to-many-field-nova/blob/master/src/Http/Controllers/ResourceController.php#L35

![image](https://user-images.githubusercontent.com/1063088/80410539-5753cf80-8890-11ea-8eec-826f1d8f77b7.png)

I don't have a `name` column, and even if I did, I would rather determine sort logic myself via `relatableQuery` as explained above. So the sorting just breaks because of this.

Two potential solutions here:

- remove `sortBy('name')` altogether
- change it to: `sortBy($optionsLabel)`

I decided to go with option 1. 