### PR TITLE
Add require attribute to belongs to many field

### DIFF
--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -156,6 +156,7 @@ class BelongsToManyField extends Field
             'panel' => $this->panel,
             'prefixComponent' => true,
             'readonly' => $this->isReadonly(app(NovaRequest::class)),
+            'required' => $this->isRequired(app(NovaRequest::class)),
             'resourceNameRelationship' => $this->resourceName,
             'sortable' => $this->sortable,
             'sortableUriKey' => $this->sortableUriKey(),


### PR DESCRIPTION
As a developer when adding `->required()` chained method, would like to display the `red asterisk (*)`, to express required elements to final users.
```
BelongsToManyField::make('Etwas', 'etwas', 'App\Nova\Etwas')
                ->required()
                ->rules(['required'])
                ->hideFromIndex(),
```

![image](https://user-images.githubusercontent.com/20247581/87755045-81b98700-c806-11ea-8904-b43fcecae04c.png)
