### PR TITLE
Added language handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ public function fields(Request $request){
 | `dependsOn`                   | String, String  | null, null | This method allows you to depend on belongsto field, this make an auto query                                                                                                 |
 | `canSelectAll`                | String, Boolean | 'Select All', true | This method allows you to have a select all checkbox and display custom message                                                                                              |
 | `showAsListInDetail`          | Boolean         | true       | This method allows you to display as list in detail                                                                                             |
-
+| `language`                    | String          | Current Locale       | This method allows for the correct display of translatable models |
 - Method optionsLabel('columnName'), this method is when you don't have column 'name' in your table and you want to label by another column name. By default it tracks by label 'name'.
 
 IMPORTANT
@@ -106,6 +106,13 @@ public function handle(ActionFields $fields, Collection $models)
 ```php
      BelongsToManyField::make('Participants', 'participant', 'App\Nova\Participant')
      ->showAsListInDetail(),
+```
+
+- Method language($language), This method allows for the correct display of translatable models
+
+```php
+     BelongsToManyField::make('Participants', 'participant', 'App\Nova\Participant')
+     ->language('en'),
 ```
 
 ### Validations

--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -1,64 +1,73 @@
 <template>
-  <panel-item :field="field">
-    <div slot="value">
-      <div v-if="field.showAsList">
-        <div class="relative rounded-lg bg-white shadow border border-60">
-          <div class="overflow-hidden rounded-b-lg rounded-t-lg">
-            <div class="border-b border-50 cursor-text font-mono text-sm py-2 px-4"
-                 v-for="(resource, key) in field.value"
-                 :key="key">
-              <router-link
-                :to="{
+    <panel-item :field="field">
+        <div slot="value">
+            <div v-if="field.showAsList">
+                <div class="relative rounded-lg bg-white shadow border border-60">
+                    <div class="overflow-hidden rounded-b-lg rounded-t-lg">
+                        <div class="border-b border-50 cursor-text font-mono text-sm py-2 px-4"
+                             v-for="(resource, key) in field.value"
+                             :key="key">
+                            <router-link
+                                :to="{
                 name: 'detail',
                 params: {
                   resourceName: field.resourceNameRelationship,
                   resourceId: resource.id,
                 },
               }"
-                class="no-underline dim text-primary font-bold"
-                v-if="field.viewable"
-              >{{resource[field.optionsLabel]}}
-              </router-link>
-              <span v-else>{{resource[field.optionsLabel]}}</span>
+                                class="no-underline dim text-primary font-bold"
+                                v-if="field.viewable"
+                            >{{resourceValue(resource[field.optionsLabel])}}
+                            </router-link>
+                            <span v-else>{{resourceValue(resource[field.optionsLabel])}}</span>
+                        </div>
+                    </div>
+                </div>
             </div>
-          </div>
-        </div>
-      </div>
-      <div v-else>
+            <div v-else>
       <span v-for="(resource, key) in field.value" class="single">
         <router-link
-          :to="{
+            :to="{
             name: 'detail',
             params: {
               resourceName: field.resourceNameRelationship,
               resourceId: resource.id,
             },
           }"
-          class="no-underline dim text-primary font-bold"
-          v-if="field.viewable"
-        >{{resource[field.optionsLabel]}}</router-link>
-        <span v-else>{{resource[field.optionsLabel]}}</span>
+            class="no-underline dim text-primary font-bold"
+            v-if="field.viewable"
+        >{{resourceValue(resource[field.optionsLabel])}}</router-link>
+        <span v-else>{{resourceValue(resource[field.optionsLabel])}}</span>
       </span>
-      </div>
-    </div>
-  </panel-item>
+            </div>
+        </div>
+    </panel-item>
 </template>
 
 <script>
-  export default {
-    props: ["resource", "resourceName", "resourceId", "field"],
-    mounted() {
-      if (this.field.showAsList) {
-        console.log(this.field)
-      }
-    }
-  };
+    export default {
+        props: ["resource", "resourceName", "resourceId", "field"],
+        mounted() {
+            if (this.field.showAsList) {
+                console.log(this.field)
+            }
+        },
+        methods: {
+            resourceValue(value) {
+                if (value instanceof Object) {
+                    return value[this.field.language]
+                } else {
+                    return value
+                }
+            }
+        },
+    };
 </script>
 
 <style lang="scss" scoped>
-  .single:not(:last-of-type) {
-    &:after {
-      content: ', ';
+    .single:not(:last-of-type) {
+        &:after {
+            content: ', ';
+        }
     }
-  }
 </style>

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -146,8 +146,23 @@
         this.optionsLabel = this.field.optionsLabel
           ? this.field.optionsLabel
           : "name";
-        this.value = this.field.value || "";
+        this.value = this.processValue(this.field.value) || "";
         this.fetchOptions();
+      },
+
+      processValue(value) {
+        if (value) {
+            for (let key in value) {
+                if (value.hasOwnProperty(key)) {
+                    if (value[key][this.optionsLabel] instanceof Object) {
+                        if (value[key][this.optionsLabel].hasOwnProperty(this.field.language)) {
+                            value[key][this.optionsLabel] = value[key][this.optionsLabel][this.field.language];
+                        }
+                    }
+                }
+            }
+        }
+        return value;
       },
 
       fetchOptions() {

--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -1,32 +1,43 @@
 <template>
-  <div>
+    <div>
     <span v-for="(resource, key) in field.value" class="single">
       <router-link
-        :to="{
+          :to="{
           name: 'detail',
           params: {
             resourceName: field.resourceNameRelationship,
             resourceId: resource.id,
           },
         }"
-        class="no-underline dim text-primary font-bold"
-        v-if="field.viewable"
-      >{{resource[field.optionsLabel]}}</router-link>
-      <span v-else>{{resource[field.optionsLabel]}}</span>
+          class="no-underline dim text-primary font-bold"
+          v-if="field.viewable"
+      >{{resourceValue(resource[field.optionsLabel])}}</router-link>
+      <span v-else>{{resourceValue(resource[field.optionsLabel])}}</span>
     </span>
-  </div>
+    </div>
 </template>
 
 <script>
-export default {
-  props: ["resourceName", "field"]
-};
+
+    export default {
+        props: ["resourceName", "field"],
+
+        methods: {
+            resourceValue(value) {
+                if (value instanceof Object) {
+                    return value[this.field.language]
+                } else {
+                    return value
+                }
+            }
+        },
+    };
 </script>
 
 <style lang="scss" scoped>
-  .single:not(:last-of-type) {
-    &:after {
-      content: ', ';
+    .single:not(:last-of-type) {
+        &:after {
+            content: ', ';
+        }
     }
-  }
 </style>

--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -2,6 +2,7 @@
 
 namespace Benjacho\BelongsToManyField;
 
+use Illuminate\Support\Facades\App;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Benjacho\BelongsToManyField\Rules\ArrayRules;
@@ -19,6 +20,7 @@ class BelongsToManyField extends Field
     public $viewable = true;
     public $showAsList = false;
     public $pivotData = [];
+    public $language = "en";
 
     /**
      * The field's component.
@@ -31,6 +33,7 @@ class BelongsToManyField extends Field
     public $relationModel;
 
     public $label = "name";
+
 
     /**
      * Create a new field.
@@ -51,6 +54,9 @@ class BelongsToManyField extends Field
         $this->resourceClass = $resource;
         $this->resourceName = $resource::uriKey();
         $this->manyToManyRelationship = $this->attribute;
+
+        $this->language = App::getLocale();
+
         $this->fillUsing(function ($request, $model, $attribute, $requestAttribute) use ($resource) {
             if (is_subclass_of($model, 'Illuminate\Database\Eloquent\Model')) {
                 $model::saved(function ($model) use ($attribute, $request) {
@@ -77,6 +83,7 @@ class BelongsToManyField extends Field
         return $this->withMeta(['optionsLabel' => $this->label]);
     }
 
+
     public function options($options)
     {
         $options = collect($options);
@@ -96,9 +103,9 @@ class BelongsToManyField extends Field
     }
 
     public function canSelectAll($messageSelectAll = 'Select All', $selectAll = true){
-      $this->selectAll = $selectAll;
-      $this->messageSelectAll = $messageSelectAll;
-      return $this->withMeta(['selectAll' => $this->selectAll, 'messageSelectAll' => $this->messageSelectAll]);
+        $this->selectAll = $selectAll;
+        $this->messageSelectAll = $messageSelectAll;
+        return $this->withMeta(['selectAll' => $this->selectAll, 'messageSelectAll' => $this->messageSelectAll]);
     }
 
     public function showAsListInDetail($showAsList = true){
@@ -109,6 +116,12 @@ class BelongsToManyField extends Field
     public function viewable($viewable = true)
     {
         $this->viewable = $viewable;
+        return $this;
+    }
+
+    public function language($language = 'en')
+    {
+        $this->language = $language;
         return $this;
     }
 
@@ -163,6 +176,7 @@ class BelongsToManyField extends Field
             'textAlign' => $this->textAlign,
             'value' => $this->value,
             'viewable' => $this->viewable,
+            'language' => $this->language,
         ], $this->meta());
     }
 


### PR DESCRIPTION
A proposed fix for issue #48.

A new method has been added:

Method language($language)
_This method allows for the correct display of translatable models and defaults to the current locale_

```
 BelongsToManyField::make('Participants', 'participant', 'App\\Nova\\Participant')
 ->language('en')
```
