### PR TITLE
Don't use $request->$attribute

### DIFF
--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -54,7 +54,7 @@ class BelongsToManyField extends Field
         $this->fillUsing(function ($request, $model, $attribute, $requestAttribute) use ($resource) {
             if (is_subclass_of($model, 'Illuminate\Database\Eloquent\Model')) {
                 $model::saved(function ($model) use ($attribute, $request) {
-                    $inp = json_decode($request->$attribute, true);
+                    $inp = json_decode($request->input($attribute), true);
                     if ($inp !== null)
                         $values = array_column($inp, 'id');
                     else
@@ -66,7 +66,7 @@ class BelongsToManyField extends Field
                         $values
                     );
                 });
-                unset($request->$attribute);
+                $request->except($attribute);
             }
         });
     }


### PR DESCRIPTION
If you use `$request->$attribute`, and `$attribute` is (for example) `files`, then the save will fail entirely because `$request->files` already exists as a public property on the Request model. 

To prevent this from happening, and because something like 'files' is a very common name, we need to start using `$request->input()` and `$request->except()`. If not, this plugin will fail in strange ways if you use it on a field called 'files', 'searchable', 'polling', 'with', 'title', 'group', ...