### PR TITLE
Use standard $title prop as default label

### DIFF
--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -30,7 +30,7 @@ class BelongsToManyField extends Field
 
     public $relationModel;
 
-    public $label = "name";
+    public $label = null;
 
     /**
      * Create a new field.
@@ -47,6 +47,10 @@ class BelongsToManyField extends Field
         $resource = $resource ?? ResourceRelationshipGuesser::guessResource($name);
 
         $this->resource = $resource;
+
+        if ($this->label === null) {
+            $this->optionsLabel(($resource)::$title ?? 'name');
+        }
 
         $this->resourceClass = $resource;
         $this->resourceName = $resource::uriKey();


### PR DESCRIPTION
If the user doesn't call the `->optionsLabel('...')` method, then we can default to field that is declared in the Resource's `$title` property. Every Resource in Nova should have this by default, so let's just use it.