### PR TITLE
Allow a callback to be passed to the options method

### DIFF
--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -10,6 +10,13 @@ use Laravel\Nova\Fields\ResourceRelationshipGuesser;
 
 class BelongsToManyField extends Field
 {
+    /**
+     * The callback to be used for the field's options.
+     *
+     * @var array|callable
+     */
+    private $optionsCallback;
+
     public $showOnIndex = true;
     public $showOnDetail = true;
     public $isAction = false;
@@ -35,9 +42,10 @@ class BelongsToManyField extends Field
     /**
      * Create a new field.
      *
-     * @param  string  $name
-     * @param  string|null  $attribute
-     * @param  string|null  $resource
+     * @param string $name
+     * @param string|null $attribute
+     * @param string|null $resource
+     *
      * @return void
      */
     //Code by @drsdre
@@ -77,10 +85,11 @@ class BelongsToManyField extends Field
         return $this->withMeta(['optionsLabel' => $this->label]);
     }
 
-    public function options($options)
+    public function options($options = [])
     {
-        $options = collect($options);
-        return $this->withMeta(['options' => $options]);
+        $this->optionsCallback = $options;
+
+        return $this;
     }
 
     public function relationModel($model)
@@ -146,6 +155,14 @@ class BelongsToManyField extends Field
 
     public function jsonSerialize()
     {
+        if (isset($this->optionsCallback)) {
+            if (is_callable($this->optionsCallback)) {
+                $this->withMeta(['options' => call_user_func($this->optionsCallback)]);
+            } else {
+                $this->withMeta(['options' => collect($this->optionsCallback)]);
+            }
+        }
+
         return array_merge([
             'attribute' => $this->attribute,
             'component' => $this->component(),

--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -155,13 +155,7 @@ class BelongsToManyField extends Field
 
     public function jsonSerialize()
     {
-        if (isset($this->optionsCallback)) {
-            if (is_callable($this->optionsCallback)) {
-                $this->withMeta(['options' => call_user_func($this->optionsCallback)]);
-            } else {
-                $this->withMeta(['options' => collect($this->optionsCallback)]);
-            }
-        }
+        $this->resolveOptions();
 
         return array_merge([
             'attribute' => $this->attribute,
@@ -194,5 +188,16 @@ class BelongsToManyField extends Field
         $this->pivotData = $attributes;
 
         return $this;
+    }
+
+    private function resolveOptions(): void
+    {
+        if (isset($this->optionsCallback)) {
+            if (is_callable($this->optionsCallback)) {
+                $this->withMeta(['options' => call_user_func($this->optionsCallback)]);
+            } else {
+                $this->withMeta(['options' => collect($this->optionsCallback)]);
+            }
+        }
     }
 }


### PR DESCRIPTION
At our company we have a lot of data, and some quite extensive models to go along with that data. We offer quite some options for our staff to use in some of our Belongs-To-Many-Fields, which all take up some memory. That usually isn't a problem, but due to the way Laravel Nova works it fetches this data for each model it finds, for example when searching for models to attach.

Simply caching this data doesn't help against the memory usage problem, as all data is still fetched from the cache and unserialized into memory.

In order to improve and limit memory usage or for other purposes, I have introduced the ability to pass a callback or closure to the `options()` method, which will only load the options at the moment of serializing the data to JSON for the Vue component. This resolves #13 as well.

In our example case we've went from 272MB of memory used in one request to 50MB.

Example usage:

```php
BelongsToManyField::make('Category', 'categories', BlogCategory::class)->options(function() {
  // Do something to get your data...
  return $data;
})
```