### PR TITLE
Replace aliased facades

### DIFF
--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -4,6 +4,7 @@ namespace Benjacho\BelongsToManyField;
 
 use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class FieldServiceProvider extends ServiceProvider
@@ -21,7 +22,7 @@ class FieldServiceProvider extends ServiceProvider
         });
 
         $this->app->booted(function () {
-            \Route::middleware(['nova'])
+            Route::middleware(['nova'])
                 ->domain(config('nova.domain', null))
                 ->prefix('nova-vendor/belongs-to-many-field')
                 ->group(__DIR__ . '/../routes/api.php');

--- a/src/Rules/ArrayRules.php
+++ b/src/Rules/ArrayRules.php
@@ -3,6 +3,7 @@
 namespace Benjacho\BelongsToManyField\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Validator;
 
 class ArrayRules implements Rule
 {
@@ -31,7 +32,7 @@ class ArrayRules implements Rule
     {
         $input = [$attribute => json_decode($value, true)];
         $this->rules = [$attribute => $this->rules];
-        $validator = \Validator::make($input, $this->rules, $this->messages($attribute));
+        $validator = Validator::make($input, $this->rules, $this->messages($attribute));
         $this->message = $validator->errors()->get($attribute);
 
         return $validator->passes();


### PR DESCRIPTION
I've replaced the aliased facades (`Route`, `Validator`) with fully qualified class names.

This fix solves the issue when someone disables the facade alias registration in Laravel config.