### PR TITLE
#50 Fix component inside nova-dependency-container

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -3,6 +3,7 @@
 namespace Benjacho\BelongsToManyField\Http\Controllers;
 
 use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Fields\FieldCollection;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class ResourceController
@@ -10,9 +11,15 @@ class ResourceController
     public function index(NovaRequest $request, $parent, $relationship, $optionsLabel, $dependsOnValue = null, $dependsOnKey = null)
     {
         $resourceClass = $request->newResource();
-        $field = $resourceClass
-            ->availableFields($request)
-            ->where('component', 'BelongsToManyField')
+        $fieldCollection = $resourceClass->availableFields($request);
+        $field = $fieldCollection->reduce(function ($carry, $item) {
+            if ($item->component === 'nova-dependency-container') {
+                $carry = $carry->merge($item->meta()['fields']);
+            } else {
+                $carry->push($item);
+            }
+            return $carry;
+        }, FieldCollection::make([]))->where('component', 'BelongsToManyField')
             ->where('attribute', $relationship)
             ->first();
         $query = $field->resourceClass::newModel();


### PR DESCRIPTION
Looking at https://github.com/Benjacho/belongs-to-many-field-nova/pull/50

We have the same problem:
this module belongs-to-many-field-nova does not work inside the third party nova package [nova-dependency-container](https://www.github.com/epartment/nova-dependency-container) due to nesting.

The issue:
When a form uses nova-dependency-container that contains a relation, the call to `'/{resource}/options/{relationship}/{optionsLabel}/{dependsOnValue?}/{dependsOnKey?}'` route fails - not finding its own component key among the fields. We just have to add the meta description of the nova-dependency-container to the query.

I found no other solution as already given in the issue mentioned above. If there is a more general solution not specifically targeting `nova-dependency-container`, would be nice.