### PR TITLE
Fixes typing error on jsonSerialize() on Nova 4

### DIFF
--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -180,7 +180,7 @@ class BelongsToManyField extends Field
         }
     }
 
-    public function jsonSerialize() : array
+    public function jsonSerialize(): array
     {
         $this->resolveOptions();
 
@@ -204,7 +204,6 @@ class BelongsToManyField extends Field
             'textAlign' => $this->textAlign,
             'value' => $this->value,
             'viewable' => $this->viewable,
-            'visible' => $this->visible,
             'validationKey' => $this->validationKey(),
         ], $this->meta());
     }


### PR DESCRIPTION
Fixes PHP Fatal error:  Declaration of Benjacho\BelongsToManyField\BelongsToManyField::jsonSerialize() must be compatible with Laravel\Nova\Fields\Field::jsonSerialize(): array